### PR TITLE
Move some stuff from the formal-vaccine project into the CompM module

### DIFF
--- a/coq/handwritten/CryptolToCoq/CompM.v
+++ b/coq/handwritten/CryptolToCoq/CompM.v
@@ -540,6 +540,16 @@ Proof.
   constructor. apply I.
 Qed.
 
+(* CompM's returnM is injective wrt monadic equivalence *)
+Lemma MonadReturnOp_CompM_injects : forall (A : Type) (x y : A),
+    returnM (M:=CompM) x ~= returnM y -> x = y.
+Proof.
+  intros. unfold returnM in H. unfold MonadReturnOp_OptionT in H.
+  unfold eqM in H. unfold MonadEqOp_OptionT in H. unfold eqM in H. unfold MonadEqOp_SetM in H.
+  assert (Some x = Some y) as Hxy.
+  { rewrite H. reflexivity. }
+  inversion Hxy; subst. reflexivity.
+Qed.
 
 (***
  *** Refinement Proofs

--- a/coq/handwritten/CryptolToCoq/CompM.v
+++ b/coq/handwritten/CryptolToCoq/CompM.v
@@ -592,6 +592,10 @@ Fixpoint refinesFun {lrt} : relation (lrtToType lrt) :=
   | LRT_Fun A lrtF => fun f1 f2 => forall a, refinesFun (f1 a) (f2 a)
   end.
 
+(* A convenient specialization of refinesFun *)
+Definition refinesFun1 {A} {B:A -> Type} : (forall a, CompM (B a)) -> (forall a, CompM (B a)) -> Prop :=
+  refinesFun (lrt:=LRT_Fun _ (fun _ => LRT_Ret _)).
+
 (* Lift refinesM to tuples of monadic functions *)
 Fixpoint refinesFunTuple {lrts} : relation (lrtTupleType lrts) :=
   match lrts return relation (lrtTupleType lrts) with


### PR DESCRIPTION
I've moved the injectivity result on `CompM` and the definition of `refinesFun1` into the `CompM` module, so they aren't cluttering the vaccine formalization work.