### PR TITLE
Adapt to renaming of package `cryptol-verifier` to `cryptol-saw-core`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ SAWCoreVectorsAsCoqVectors (H)   SAWCoreVectorsAsCoqLists (H)
   does not provide.
 
 * `CryptolPrimitivesForSAWCore` is generated from `Cryptol.sawcore`, available
-  in the `cryptol-verifier` project.
+  in the `cryptol-saw-core` project.
 
 * `SAWCorePreludeExtra` defines useful functions for
   `CryptolPrimitivesForSAWCoreExtra` to use.

--- a/saw-core-coq.cabal
+++ b/saw-core-coq.cabal
@@ -18,7 +18,7 @@ library
     ansi-wl-pprint,
     base == 4.*,
     cryptol,
-    cryptol-verifier,
+    cryptol-saw-core,
     containers,
     interpolate,
     lens,


### PR DESCRIPTION
See GaloisInc/saw-core#62.