### PR TITLE
Add soft line break for let expressions.

### DIFF
--- a/src/Language/Coq/Pretty.hs
+++ b/src/Language/Coq/Pretty.hs
@@ -87,7 +87,7 @@ ppTerm p e =
     Let x bs mty t body ->
       parensIf (p > PrecLambda) $
       text "let" <+> ppIdent x <+> ppBinders bs <+> ppMaybeTy mty <+>
-      text ":=" <+> ppTerm PrecNone t <+> text "in" <+> ppTerm PrecLambda body
+      text ":=" <+> ppTerm PrecNone t <+> text "in" </> ppTerm PrecLambda body
     If c t f ->
       parensIf (p > PrecLambda) $
       text "if" <+> ppTerm PrecNone c <+>


### PR DESCRIPTION
This is a partial fix for #16.

Now it is possible to print very large SAW terms that produce
a large number of nested let expressions, without generating
one extremely long line.